### PR TITLE
fix: images are now compatible macm1

### DIFF
--- a/.github/release.sh
+++ b/.github/release.sh
@@ -56,7 +56,7 @@ fi
 
 docker buildx build \
   --output type=image,push=true \
-  --platform "amd64,arm64,arm" \
+  --platform "linux/amd64,linux/arm64,linux/arm" \
   ${tag} \
   --build-arg CI=true \
   --cache-from type=local,src=~/.docker-cache/template-node12 \

--- a/template/node12/Dockerfile
+++ b/template/node12/Dockerfile
@@ -1,5 +1,5 @@
-FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/of-watchdog:0.8.4 as watchdog
-FROM --platform=${TARGETPLATFORM:-linux/amd64} node:12-alpine as ship
+FROM ghcr.io/openfaas/of-watchdog:0.8.4 as watchdog
+FROM node:12-alpine as ship
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM


### PR DESCRIPTION
I've created this PR to test if the image is woking on macM1 without the platform target. 

@shiipou  if you can build the template-node12 on this branch and push it to docker hub under a specific tag so i can test it with my mac it would be amazing :) 